### PR TITLE
fix: move react to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   "dependencies": {
     "prop-types": "^15.6.1",
     "ramda": "^0.25.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0",
     "recompose": "^0.30.0",
     "rxjs": "^6.2.0"
+  },
+  "peerDependencies": {
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
hi @cettoana , if you agree I switched react and react-dom to peerDependencies as it is problematic to have them as simple dependencies (especially in typescript projects)